### PR TITLE
build(deps): Upgrade outdated dependencies, supporting frunk v0.4

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,4 +12,4 @@ license = "MIT OR Apache-2.0"
 repository = "Metaswitch/frunk-enum"
 
 [dependencies]
-frunk = "0.3.1"
+frunk = ">=0.3.1, <0.5"

--- a/derive-tests/Cargo.toml
+++ b/derive-tests/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 [dependencies]
 frunk-enum-derive = { path = "../derive" }
 frunk-enum-core = { path = "../core" }
-frunk = "0.3.1"
-frunk_core = "0.3.1"
+frunk = "0.4.0"
+frunk_core = "0.4.0"

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -15,13 +15,13 @@ repository = "Metaswitch/frunk-enum"
 proc-macro = true
 
 [dependencies]
-syn = { version = "0.15", features = ["full"] }
-proc-macro2 = "0.4"
-quote = "0.6"
+syn = { version = ">=0.15, <2.0", features = ["full"] }
+proc-macro2 = ">=0.4, <2.0"
+quote = ">=0.6, <2.0"
 itertools = "0.10"
-frunk_proc_macro_helpers = "0.0.5"
+frunk_proc_macro_helpers = ">=0.0.5, <0.2"
 
 [dev-dependencies]
 frunk-enum-core = { version = "0.2.1", path = "../core" }
-frunk = "0.3.1"
-frunk_core = "0.3.1"
+frunk = "0.4.0"
+frunk_core = "0.4.0"


### PR DESCRIPTION
Added support for frunk v0.4, syn v1.0, proc-macro2 v1.0, quote v1.0, and frunk_proc_macro_helpers v0.1